### PR TITLE
fix: resolve @testing-library/dom peer dep and exclude test files from build

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "recharts": "^2.13.3"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.0.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,6 @@
     "noFallthroughCasesInSwitch": true,
     "allowSyntheticDefaultImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.tsx", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
- Add @testing-library/dom@^10.0.0 as a dev dependency (required peer dep of @testing-library/react@16)
- Exclude *.test.tsx and *.test.ts from tsconfig.json so tsc during build does not fail on test-only imports (screen, waitFor)

https://claude.ai/code/session_01CvHgnjmkHhKL16YaNgNXBt