### PR TITLE
fix: add multi-provider API fallback, retry logic, and stale cache UI

### DIFF
--- a/src/History/History.test.tsx
+++ b/src/History/History.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import History from "./History";
 
@@ -57,7 +57,7 @@ describe("History", () => {
     expect(screen.getByText(/Ethereum/i)).toBeInTheDocument();
   });
 
-  it("shows error state when API call fails", async () => {
+  it("shows error state when API call fails and no cache exists", async () => {
     mockGetHistoricalDays.mockRejectedValue(new Error("Network error"));
     render(<History currency="AUD" />);
 
@@ -80,36 +80,34 @@ describe("History", () => {
     });
   });
 
-  it("increments the day count when + button is clicked", async () => {
+  it("changes the amount when typing in the number input", async () => {
     mockGetHistoricalDays.mockResolvedValue(buildMockResponse());
     render(<History currency="AUD" />);
 
-    // Initial display is "7 days"
-    expect(screen.getByText("7 days")).toBeInTheDocument();
+    const input = screen.getByRole("spinbutton", { name: "Duration amount" });
+    expect(input).toHaveValue(7);
 
-    await userEvent.click(screen.getByRole("button", { name: "Increase days" }));
-    expect(screen.getByText("8 days")).toBeInTheDocument();
+    fireEvent.change(input, { target: { value: "14" } });
+    expect(input).toHaveValue(14);
   });
 
-  it("decrements the day count when − button is clicked", async () => {
+  it("clamps amount to the unit's minimum when a value below min is entered", () => {
     mockGetHistoricalDays.mockResolvedValue(buildMockResponse());
     render(<History currency="AUD" />);
 
-    await userEvent.click(screen.getByRole("button", { name: "Decrease days" }));
-    expect(screen.getByText("6 days")).toBeInTheDocument();
+    const input = screen.getByRole("spinbutton", { name: "Duration amount" });
+    fireEvent.change(input, { target: { value: "0" } });
+    // Min for "days" unit is 2
+    expect(input).toHaveValue(2);
   });
 
-  it("disables decrement button at minimum (2 days)", async () => {
-    mockGetHistoricalDays.mockResolvedValue(buildMockResponse(2));
+  it("switches to the weeks unit", async () => {
+    mockGetHistoricalDays.mockResolvedValue(buildMockResponse());
     render(<History currency="AUD" />);
 
-    // Reduce to minimum
-    for (let i = 0; i < 10; i++) {
-      const btn = screen.getByRole("button", { name: "Decrease days" });
-      if (!btn.hasAttribute("disabled")) await userEvent.click(btn);
-    }
-
-    expect(screen.getByRole("button", { name: "Decrease days" })).toBeDisabled();
+    await userEvent.click(screen.getByText("weeks"));
+    // weeks button should now appear selected (has bg-white class)
+    expect(screen.getByText("weeks").className).toMatch(/bg-white/);
   });
 
   it("restores data from localStorage when offline", async () => {
@@ -125,5 +123,22 @@ describe("History", () => {
     });
 
     expect(mockGetHistoricalDays).not.toHaveBeenCalled();
+  });
+
+  it("shows stale data banner when falling back to cache on API error", async () => {
+    mockGetHistoricalDays.mockRejectedValue(new Error("Rate limited"));
+
+    const cachedEntry = {
+      data: [{ date: "Nov 1", BTC: 45000, ETH: 2500 }],
+      cachedAt: Date.now() - 3600_000, // 1 hour ago
+    };
+    localStorage.setItem("history-chart-7", JSON.stringify(cachedEntry));
+
+    render(<History currency="AUD" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Historical data unavailable/i)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Bitcoin/i)).toBeInTheDocument();
   });
 });

--- a/src/History/History.tsx
+++ b/src/History/History.tsx
@@ -10,6 +10,7 @@ import {
 } from "recharts";
 import { getPriceHistoricalDays } from "../cryptoService";
 import { format, fromUnixTime } from "date-fns";
+import { enAU } from "date-fns/locale";
 import { ErrorState, LoadingState, EmptyState } from "../Results";
 import { formatCurrency, COIN_META, ALL_COIN_KEYS } from "../utils";
 import useStatus from "../hooks/useStatus";
@@ -21,6 +22,12 @@ interface HistoryProps {
 interface ChartDataPoint {
   date: string;
   [key: string]: string | number;
+}
+
+/** Cache entry stored in localStorage — wraps chart data with a timestamp */
+interface HistoryCacheEntry {
+  data: ChartDataPoint[];
+  cachedAt: number; // Unix ms
 }
 
 type TimeUnit = "days" | "weeks" | "months";
@@ -37,6 +44,8 @@ const History = ({ currency }: HistoryProps) => {
   const [chartData, setChartData] = useState<ChartDataPoint[]>([]);
   const [error, setError] = useState<string>("");
   const [activeView, setActiveView] = useState<"chart" | "table">("chart");
+  const [isStale, setIsStale] = useState(false);
+  const [cacheTime, setCacheTime] = useState<string>();
   const { Status, setStatus } = useStatus("loading");
 
   const numDays = UNIT_CONFIG[unit].toDays(amount);
@@ -54,14 +63,32 @@ const History = ({ currency }: HistoryProps) => {
   };
 
   const restoreStateFromLocalStorage = useCallback(() => {
-    const saved = localStorage.getItem(`history-chart-${numDays}`);
-    if (saved) {
-      setChartData(JSON.parse(saved));
+    const raw = localStorage.getItem(`history-chart-${numDays}`);
+    if (!raw) {
+      setStatus("empty");
+      return;
+    }
+    try {
+      const parsed = JSON.parse(raw) as HistoryCacheEntry | ChartDataPoint[];
+      const entry = Array.isArray(parsed)
+        ? { data: parsed, cachedAt: 0 }
+        : parsed;
+
+      setChartData(entry.data);
+      if (entry.cachedAt) {
+        setCacheTime(format(new Date(entry.cachedAt), "HH:mm d MMM", { locale: enAU }));
+      }
+      setIsStale(true);
       setStatus("success");
-    } else {
+    } catch {
       setStatus("empty");
     }
   }, [numDays, setStatus]);
+
+  const saveToLocalStorage = (points: ChartDataPoint[]) => {
+    const entry: HistoryCacheEntry = { data: points, cachedAt: Date.now() };
+    localStorage.setItem(`history-chart-${numDays}`, JSON.stringify(entry));
+  };
 
   const fetchDays = useCallback(async () => {
     setStatus("loading");
@@ -73,19 +100,44 @@ const History = ({ currency }: HistoryProps) => {
       const points: ChartDataPoint[] = [];
       const firstCoinData = results[0].Data;
       for (let i = numDays - 1; i >= 0; i--) {
+        const entry = firstCoinData[i];
+        if (!entry) continue;
         const point: ChartDataPoint = {
-          date: format(fromUnixTime(firstCoinData[i].time), "MMM d"),
+          date: format(fromUnixTime(entry.time), "MMM d"),
         };
         ALL_COIN_KEYS.forEach((coin, idx) => {
-          point[coin] = results[idx].Data[i].close;
+          const d = results[idx].Data[i];
+          point[coin] = d ? d.close : 0;
         });
         points.push(point);
       }
 
       setChartData(points);
-      localStorage.setItem(`history-chart-${numDays}`, JSON.stringify(points));
+      saveToLocalStorage(points);
+      setIsStale(false);
+      setCacheTime(undefined);
       setStatus("success");
     } catch (err) {
+      // All providers failed — try cache with stale warning
+      const raw = localStorage.getItem(`history-chart-${numDays}`);
+      if (raw) {
+        try {
+          const parsed = JSON.parse(raw) as HistoryCacheEntry | ChartDataPoint[];
+          const cacheEntry = Array.isArray(parsed)
+            ? { data: parsed, cachedAt: 0 }
+            : parsed;
+
+          setChartData(cacheEntry.data);
+          if (cacheEntry.cachedAt) {
+            setCacheTime(format(new Date(cacheEntry.cachedAt), "HH:mm d MMM", { locale: enAU }));
+          }
+          setIsStale(true);
+          setStatus("success");
+          return;
+        } catch {
+          // fall through to error state
+        }
+      }
       setError(String(err));
       setStatus("error");
     }
@@ -159,6 +211,22 @@ const History = ({ currency }: HistoryProps) => {
           </div>
         </div>
       </div>
+
+      {isStale && (
+        <div className="mb-4 flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-700 dark:border-amber-800 dark:bg-amber-900/20 dark:text-amber-400">
+          <svg className="h-4 w-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+          </svg>
+          Historical data unavailable — showing cached data
+          {cacheTime ? ` from ${cacheTime}` : ""}.{" "}
+          <button
+            onClick={fetchDays}
+            className="ml-1 underline underline-offset-2 hover:text-amber-900 dark:hover:text-amber-300"
+          >
+            Retry
+          </button>
+        </div>
+      )}
 
       <Status
         loading={

--- a/src/Today/Today.tsx
+++ b/src/Today/Today.tsx
@@ -12,6 +12,12 @@ const cluster = import.meta.env.VITE_PUSHER_CLUSTER;
 const appKey = import.meta.env.VITE_PUSHER_KEY;
 const pusherApi = import.meta.env.VITE_PUSHER_API;
 
+/** Cache entry stored in localStorage — wraps the price payload with a timestamp */
+interface TodayCacheEntry {
+  data: ITodayCurrencyPriceData;
+  cachedAt: number; // Unix ms
+}
+
 interface TodayProps {
   currency: Currency;
   onPriceUpdate?: (prices: Record<CoinKey, number>) => void;
@@ -54,28 +60,44 @@ const Today = ({ currency, onPriceUpdate }: TodayProps) => {
   const [todayPrice, setTodayPrice] = useState<ITodayCurrencyPriceData>();
   const [error, setError] = useState<string | null>(null);
   const [lastUpdated, setLastUpdated] = useState<string>();
+  const [isStale, setIsStale] = useState(false);
+  const [cacheTime, setCacheTime] = useState<string>();
   const { Status, setStatus } = useStatus("loading");
   const timerRef = useRef<ReturnType<typeof setTimeout>>();
-
-  const saveStateToLocalStorage = (today: ITodayCurrencyPriceData) => {
-    localStorage.setItem("today-state", JSON.stringify(today));
-  };
-
-  const restoreStateFromLocalStorage = () => {
-    const saved = localStorage.getItem("today-state");
-    if (saved) {
-      setTodayPrice(JSON.parse(saved));
-      setStatus("success");
-    } else {
-      setStatus("empty");
-    }
-  };
 
   const getCurrentTimeString = () =>
     format(new Date(), "HH:mm", { locale: enAU });
 
+  const saveStateToLocalStorage = (today: ITodayCurrencyPriceData) => {
+    const entry: TodayCacheEntry = { data: today, cachedAt: Date.now() };
+    localStorage.setItem("today-state", JSON.stringify(entry));
+  };
+
+  const restoreStateFromLocalStorage = () => {
+    const raw = localStorage.getItem("today-state");
+    if (!raw) {
+      setStatus("empty");
+      return;
+    }
+    try {
+      // Support both the new { data, cachedAt } shape and the old plain shape
+      const parsed = JSON.parse(raw) as TodayCacheEntry | ITodayCurrencyPriceData;
+      const entry = "cachedAt" in parsed
+        ? parsed
+        : { data: parsed as ITodayCurrencyPriceData, cachedAt: 0 };
+
+      setTodayPrice(entry.data);
+      if (entry.cachedAt) {
+        setCacheTime(format(new Date(entry.cachedAt), "HH:mm d MMM", { locale: enAU }));
+      }
+      setIsStale(true);
+      setStatus("success");
+    } catch {
+      setStatus("empty");
+    }
+  };
+
   const sendPricePusher = (response: ITodayCurrencyPriceData) => {
-    // Build payload from the fresh response only – avoids stale closure over todayPrice state.
     const payload: Record<string, string | number | undefined> = {
       date: response.date,
     };
@@ -98,9 +120,10 @@ const Today = ({ currency, onPriceUpdate }: TodayProps) => {
       saveStateToLocalStorage(today);
       setTodayPrice(today);
       setLastUpdated(getCurrentTimeString());
+      setIsStale(false);
+      setCacheTime(undefined);
       setStatus("success");
 
-      // Notify parent with raw numeric prices for alert checking
       if (onPriceUpdate) {
         const rawPrices: Partial<Record<CoinKey, number>> = {};
         ALL_COIN_KEYS.forEach((key) => {
@@ -115,6 +138,26 @@ const Today = ({ currency, onPriceUpdate }: TodayProps) => {
   };
 
   const handleError = (err: unknown) => {
+    // All providers failed — attempt to show cached data with a stale warning
+    const raw = localStorage.getItem("today-state");
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw) as TodayCacheEntry | ITodayCurrencyPriceData;
+        const entry = "cachedAt" in parsed
+          ? parsed
+          : { data: parsed as ITodayCurrencyPriceData, cachedAt: 0 };
+
+        setTodayPrice(entry.data);
+        if (entry.cachedAt) {
+          setCacheTime(format(new Date(entry.cachedAt), "HH:mm d MMM", { locale: enAU }));
+        }
+        setIsStale(true);
+        setStatus("success");
+        return;
+      } catch {
+        // fall through to error state
+      }
+    }
     setError(String(err));
     setStatus("error");
   };
@@ -175,17 +218,37 @@ const Today = ({ currency, onPriceUpdate }: TodayProps) => {
     <section>
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-2">
-          <span className="w-2 h-2 rounded-full bg-emerald-500 animate-pulse-slow"></span>
+          <span className={`w-2 h-2 rounded-full ${isStale ? "bg-amber-400" : "bg-emerald-500 animate-pulse-slow"}`}></span>
           <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
             Live Prices
           </h2>
         </div>
-        {lastUpdated && (
+        {isStale && cacheTime ? (
+          <p className="text-xs text-amber-600 dark:text-amber-400">
+            Cached data from {cacheTime}
+          </p>
+        ) : lastUpdated ? (
           <p className="text-xs text-slate-400 dark:text-slate-500">
             Updated {lastUpdated}
           </p>
-        )}
+        ) : null}
       </div>
+
+      {isStale && (
+        <div className="mb-4 flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-700 dark:border-amber-800 dark:bg-amber-900/20 dark:text-amber-400">
+          <svg className="h-4 w-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+          </svg>
+          Live prices unavailable — showing cached data
+          {cacheTime ? ` from ${cacheTime}` : ""}.{" "}
+          <button
+            onClick={() => fetchResults()}
+            className="ml-1 underline underline-offset-2 hover:text-amber-900 dark:hover:text-amber-300"
+          >
+            Retry
+          </button>
+        </div>
+      )}
 
       <Status
         loading={

--- a/src/Today/Today.tsx
+++ b/src/Today/Today.tsx
@@ -86,7 +86,7 @@ const Today = ({ currency, onPriceUpdate }: TodayProps) => {
         ? parsed
         : { data: parsed as ITodayCurrencyPriceData, cachedAt: 0 };
 
-      setTodayPrice(entry.data);
+      setTodayPrice(entry.data as ITodayCurrencyPriceData);
       if (entry.cachedAt) {
         setCacheTime(format(new Date(entry.cachedAt), "HH:mm d MMM", { locale: enAU }));
       }
@@ -147,7 +147,7 @@ const Today = ({ currency, onPriceUpdate }: TodayProps) => {
           ? parsed
           : { data: parsed as ITodayCurrencyPriceData, cachedAt: 0 };
 
-        setTodayPrice(entry.data);
+        setTodayPrice(entry.data as ITodayCurrencyPriceData);
         if (entry.cachedAt) {
           setCacheTime(format(new Date(entry.cachedAt), "HH:mm d MMM", { locale: enAU }));
         }

--- a/src/apiProviders.test.ts
+++ b/src/apiProviders.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { withRetry } from "./apiProviders";
+
+describe("withRetry", () => {
+  it("returns the result immediately on first success", async () => {
+    const fn = vi.fn().mockResolvedValue("ok");
+    const result = await withRetry(fn, 3, 0);
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries on failure and succeeds on the second attempt", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("fail"))
+      .mockResolvedValueOnce("ok");
+
+    const result = await withRetry(fn, 3, 0);
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws the last error after exhausting all attempts", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("fail 1"))
+      .mockRejectedValueOnce(new Error("fail 2"))
+      .mockRejectedValueOnce(new Error("fail 3"));
+
+    await expect(withRetry(fn, 3, 0)).rejects.toThrow("fail 3");
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it("respects maxAttempts=1 (no retries)", async () => {
+    const fn = vi.fn().mockRejectedValue(new Error("immediate fail"));
+
+    await expect(withRetry(fn, 1, 0)).rejects.toThrow("immediate fail");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry after a successful first call", async () => {
+    const fn = vi.fn().mockResolvedValue(42);
+    await withRetry(fn, 3, 0);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/apiProviders.ts
+++ b/src/apiProviders.ts
@@ -1,0 +1,141 @@
+/**
+ * Alternative API providers for crypto price data.
+ *
+ * Provider priority:
+ *   1. CoinGecko (free demo tier, 50 req/min) — set VITE_COINGECKO_API_KEY for higher limits
+ *   2. CryptoCompare (original, kept as fallback)
+ *
+ * All fetches go through withRetry() so transient rate-limit errors are retried
+ * with exponential back-off before the next provider is tried.
+ */
+
+import axios from "axios";
+
+// ---------------------------------------------------------------------------
+// Retry utility
+// ---------------------------------------------------------------------------
+
+/**
+ * Calls `fn` up to `maxAttempts` times. On failure, waits
+ * baseDelayMs * 2^attempt ms before the next attempt.
+ */
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  maxAttempts = 3,
+  baseDelayMs = 1000
+): Promise<T> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err;
+      if (attempt < maxAttempts - 1) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, baseDelayMs * 2 ** attempt)
+        );
+      }
+    }
+  }
+  throw lastError;
+}
+
+// ---------------------------------------------------------------------------
+// CoinGecko provider
+// ---------------------------------------------------------------------------
+
+const COINGECKO_BASE = "https://api.coingecko.com/api/v3";
+const coingeckoApiKey = import.meta.env.VITE_COINGECKO_API_KEY as
+  | string
+  | undefined;
+
+/** Maps our internal CoinKey symbols to CoinGecko coin IDs */
+export const COINGECKO_IDS: Record<CoinKey, string> = {
+  BTC: "bitcoin",
+  ETH: "ethereum",
+  XRP: "ripple",
+  SOL: "solana",
+  DOGE: "dogecoin",
+  ADA: "cardano",
+  LTC: "litecoin",
+};
+
+function coingeckoHeaders(): Record<string, string> {
+  return coingeckoApiKey ? { "x-cg-demo-api-key": coingeckoApiKey } : {};
+}
+
+/**
+ * Fetch current prices from CoinGecko.
+ * Returns data in the same shape as IPriceData (uppercase keys, string values).
+ */
+export async function fetchMultiPriceCoinGecko(
+  coins: CoinKey[],
+  currencies: string[]
+): Promise<IPriceData> {
+  const ids = coins.map((c) => COINGECKO_IDS[c]).join(",");
+  const vs_currencies = currencies.map((c) => c.toLowerCase()).join(",");
+
+  const { data } = await axios.get<Record<string, Record<string, number>>>(
+    `${COINGECKO_BASE}/simple/price`,
+    {
+      params: { ids, vs_currencies },
+      headers: coingeckoHeaders(),
+    }
+  );
+
+  const result: IPriceData = {};
+  coins.forEach((coin) => {
+    const geckoData = data[COINGECKO_IDS[coin]];
+    if (geckoData) {
+      result[coin] = {};
+      currencies.forEach((currency) => {
+        const price = geckoData[currency.toLowerCase()];
+        if (price !== undefined) {
+          result[coin]![currency] = String(price);
+        }
+      });
+    }
+  });
+  return result;
+}
+
+/**
+ * Fetch daily historical OHLC data from CoinGecko.
+ * Returns data shaped as { Data: IHistoricalPriceData[] } matching the
+ * CryptoCompare histoday format that the rest of the app expects.
+ *
+ * Note: CoinGecko's market_chart endpoint is used so any number of days works.
+ * Only close prices are available; open/high/low are set to the same value.
+ */
+export async function fetchHistoricalDaysCoinGecko(
+  coin: CoinKey,
+  currency: Currency,
+  days: number
+): Promise<{ Data: IHistoricalPriceData[] }> {
+  const id = COINGECKO_IDS[coin];
+
+  // market_chart?interval=daily gives one data point per day for arbitrary N
+  const { data } = await axios.get<{
+    prices: [number, number][];
+    total_volumes: [number, number][];
+  }>(`${COINGECKO_BASE}/coins/${id}/market_chart`, {
+    params: { vs_currency: currency.toLowerCase(), days, interval: "daily" },
+    headers: coingeckoHeaders(),
+  });
+
+  const historicalData: IHistoricalPriceData[] = data.prices.map(
+    ([tsMs, price], i) => ({
+      time: Math.floor(tsMs / 1000),
+      open: price,
+      high: price,
+      low: price,
+      close: price,
+      volumefrom: 0,
+      volumeto: data.total_volumes[i]?.[1] ?? 0,
+      conversionType: "direct" as const,
+      conversionSymbol: "" as const,
+    })
+  );
+
+  return { Data: historicalData };
+}

--- a/src/cryptoService.test.ts
+++ b/src/cryptoService.test.ts
@@ -1,91 +1,157 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { getPriceMulti, getPriceHistorical, getPriceHistoricalDays } from "./cryptoService";
 
-// Mock the axios client module used by cryptoService
+// Mock CoinGecko provider functions
+vi.mock("./apiProviders", () => ({
+  withRetry: vi.fn((fn: () => Promise<unknown>) => fn()),
+  fetchMultiPriceCoinGecko: vi.fn(),
+  fetchHistoricalDaysCoinGecko: vi.fn(),
+  COINGECKO_IDS: {
+    BTC: "bitcoin",
+    ETH: "ethereum",
+    XRP: "ripple",
+    SOL: "solana",
+    DOGE: "dogecoin",
+    ADA: "cardano",
+    LTC: "litecoin",
+  },
+}));
+
+// Mock the CryptoCompare axios client (used as fallback)
 vi.mock("./api", () => ({
   default: {
     get: vi.fn(),
   },
 }));
 
+import { fetchMultiPriceCoinGecko, fetchHistoricalDaysCoinGecko, withRetry } from "./apiProviders";
 import cryptoCompareClient from "./api";
 
-const mockGet = vi.mocked(cryptoCompareClient.get);
+const mockCoinGeckoMulti = vi.mocked(fetchMultiPriceCoinGecko);
+const mockCoinGeckoHistory = vi.mocked(fetchHistoricalDaysCoinGecko);
+const mockCCGet = vi.mocked(cryptoCompareClient.get);
+const mockWithRetry = vi.mocked(withRetry);
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Default withRetry to just call through
+  mockWithRetry.mockImplementation((fn) => fn());
 });
 
+// ---------------------------------------------------------------------------
+// getPriceMulti
+// ---------------------------------------------------------------------------
+
 describe("getPriceMulti", () => {
-  it("calls the pricemulti endpoint with coins and currencies", async () => {
-    const mockResponse = {
-      data: { BTC: { AUD: "150000.00" }, ETH: { AUD: "5000.00" } },
-    };
-    mockGet.mockResolvedValueOnce(mockResponse);
+  it("returns data from CoinGecko when it succeeds", async () => {
+    const geckoData: IPriceData = { BTC: { AUD: "150000" }, ETH: { AUD: "5000" } };
+    mockCoinGeckoMulti.mockResolvedValueOnce(geckoData);
 
     const result = await getPriceMulti(["BTC", "ETH"], ["AUD"]);
 
-    expect(mockGet).toHaveBeenCalledWith("pricemulti", {
-      params: { fsyms: ["BTC", "ETH"], tsyms: ["AUD"] },
+    expect(mockCoinGeckoMulti).toHaveBeenCalledWith(["BTC", "ETH"], ["AUD"]);
+    expect(result).toEqual(geckoData);
+    expect(mockCCGet).not.toHaveBeenCalled();
+  });
+
+  it("falls back to CryptoCompare when CoinGecko fails", async () => {
+    mockCoinGeckoMulti.mockRejectedValueOnce(new Error("Rate limited"));
+    const ccData: IPriceData = { BTC: { AUD: "149000" } };
+    mockCCGet.mockResolvedValueOnce({ data: ccData });
+
+    const result = await getPriceMulti(["BTC"], ["AUD"]);
+
+    expect(mockCoinGeckoMulti).toHaveBeenCalled();
+    expect(mockCCGet).toHaveBeenCalledWith("pricemulti", { params: { fsyms: ["BTC"], tsyms: ["AUD"] } });
+    expect(result).toEqual(ccData);
+  });
+
+  it("throws when both CoinGecko and CryptoCompare fail", async () => {
+    mockCoinGeckoMulti.mockRejectedValueOnce(new Error("CoinGecko down"));
+    mockCCGet.mockRejectedValueOnce(new Error("CryptoCompare down"));
+
+    await expect(getPriceMulti(["BTC"], ["AUD"])).rejects.toThrow("CryptoCompare down");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getPriceHistorical
+// ---------------------------------------------------------------------------
+
+describe("getPriceHistorical", () => {
+  it("calls the CryptoCompare pricehistorical endpoint", async () => {
+    const ts = 1700000000;
+    const mockResponse = { data: { BTC: { AUD: "40000.00" } } };
+    mockCCGet.mockResolvedValueOnce(mockResponse);
+
+    const result = await getPriceHistorical("BTC", ["AUD"], ts);
+
+    expect(mockCCGet).toHaveBeenCalledWith("pricehistorical", {
+      params: { fsym: "BTC", tsyms: ["AUD"], ts },
     });
     expect(result).toEqual(mockResponse.data);
   });
 
   it("propagates errors from the API client", async () => {
-    mockGet.mockRejectedValueOnce(new Error("Network error"));
-    await expect(getPriceMulti(["BTC"], ["AUD"])).rejects.toThrow("Network error");
+    mockCCGet.mockRejectedValueOnce(new Error("Network error"));
+    await expect(getPriceHistorical("BTC", ["AUD"], 1700000000)).rejects.toThrow("Network error");
   });
 });
 
-describe("getPriceHistorical", () => {
-  it("calls the pricehistorical endpoint with the correct params", async () => {
-    const ts = 1700000000;
-    const mockResponse = { data: { BTC: { AUD: "40000.00" } } };
-    mockGet.mockResolvedValueOnce(mockResponse);
-
-    const result = await getPriceHistorical("BTC", ["AUD"], ts);
-
-    expect(mockGet).toHaveBeenCalledWith("pricehistorical", {
-      params: { fsym: "BTC", tsyms: ["AUD"], ts },
-    });
-    expect(result).toEqual(mockResponse.data);
-  });
-});
+// ---------------------------------------------------------------------------
+// getPriceHistoricalDays
+// ---------------------------------------------------------------------------
 
 describe("getPriceHistoricalDays", () => {
-  const mockHistoday = {
-    data: {
-      Data: [
-        { time: 1700000000, high: 45000, low: 40000, open: 42000, close: 44000, volumefrom: 100, volumeto: 4400000, conversionType: "direct", conversionSymbol: "" },
-      ],
+  const mockHistoricalData: IHistoricalPriceData[] = [
+    {
+      time: 1700000000,
+      high: 45000,
+      low: 40000,
+      open: 42000,
+      close: 44000,
+      volumefrom: 100,
+      volumeto: 4400000,
+      conversionType: "direct",
+      conversionSymbol: "",
     },
-  };
+  ];
 
-  it("calls the histoday endpoint with defaults", async () => {
-    mockGet.mockResolvedValueOnce(mockHistoday);
+  it("returns data from CoinGecko when it succeeds", async () => {
+    mockCoinGeckoHistory.mockResolvedValueOnce({ Data: mockHistoricalData });
 
-    const result = await getPriceHistoricalDays("BTC");
+    const result = await getPriceHistoricalDays("BTC", "AUD", 10);
 
-    expect(mockGet).toHaveBeenCalledWith("histoday", {
+    expect(mockCoinGeckoHistory).toHaveBeenCalledWith("BTC", "AUD", 10);
+    expect(result.Data).toEqual(mockHistoricalData);
+    expect(mockCCGet).not.toHaveBeenCalled();
+  });
+
+  it("falls back to CryptoCompare when CoinGecko fails", async () => {
+    mockCoinGeckoHistory.mockRejectedValueOnce(new Error("Rate limited"));
+    mockCCGet.mockResolvedValueOnce({ data: { Data: mockHistoricalData } });
+
+    const result = await getPriceHistoricalDays("BTC", "AUD", 10);
+
+    expect(mockCoinGeckoHistory).toHaveBeenCalled();
+    expect(mockCCGet).toHaveBeenCalledWith("histoday", {
       params: { fsym: "BTC", tsym: "AUD", limit: 10 },
     });
-    expect(result).toEqual(mockHistoday.data);
+    expect(result.Data).toEqual(mockHistoricalData);
   });
 
-  it("accepts custom currency and limit", async () => {
-    mockGet.mockResolvedValueOnce(mockHistoday);
+  it("uses AUD and limit=10 as defaults", async () => {
+    mockCoinGeckoHistory.mockResolvedValueOnce({ Data: mockHistoricalData });
 
-    await getPriceHistoricalDays("ETH", "USD", 30);
+    await getPriceHistoricalDays("ETH");
 
-    expect(mockGet).toHaveBeenCalledWith("histoday", {
-      params: { fsym: "ETH", tsym: "USD", limit: 30 },
-    });
+    expect(mockCoinGeckoHistory).toHaveBeenCalledWith("ETH", "AUD", 10);
   });
 
-  it("returns the Data array from the response", async () => {
-    mockGet.mockResolvedValueOnce(mockHistoday);
-    const result = await getPriceHistoricalDays("BTC");
-    expect(Array.isArray(result.Data)).toBe(true);
-    expect(result.Data[0].close).toBe(44000);
+  it("throws when both providers fail", async () => {
+    mockCoinGeckoHistory.mockRejectedValueOnce(new Error("CoinGecko down"));
+    mockCCGet.mockRejectedValueOnce(new Error("CryptoCompare down"));
+
+    await expect(getPriceHistoricalDays("BTC")).rejects.toThrow("CryptoCompare down");
   });
 });

--- a/src/cryptoService.ts
+++ b/src/cryptoService.ts
@@ -1,30 +1,102 @@
-import cryptoCompareClient from "./api";
+/**
+ * Crypto price service — multi-provider with retry and fallback.
+ *
+ * Provider order for live prices:
+ *   1. CoinGecko   (withRetry, up to 3 attempts)
+ *   2. CryptoCompare (withRetry, up to 3 attempts)
+ *
+ * Provider order for historical data:
+ *   1. CoinGecko   (withRetry, up to 3 attempts)
+ *   2. CryptoCompare (withRetry, up to 3 attempts)
+ *
+ * If all providers fail, the error is re-thrown so callers can fall back to
+ * their own localStorage cache and surface a stale-data warning.
+ */
 
-export const getPriceMulti = async (
+import cryptoCompareClient from "./api";
+import {
+  withRetry,
+  fetchMultiPriceCoinGecko,
+  fetchHistoricalDaysCoinGecko,
+} from "./apiProviders";
+
+// ---------------------------------------------------------------------------
+// CryptoCompare helpers (kept as fallback)
+// ---------------------------------------------------------------------------
+
+async function fetchMultiPriceCryptoCompare(
   fsyms: CoinKey[],
   tsyms: string[]
-): Promise<IPriceData> =>
-  (
+): Promise<IPriceData> {
+  return (
     await cryptoCompareClient.get("pricemulti", {
       params: { fsyms, tsyms },
     })
   ).data;
+}
 
+async function fetchHistoricalDaysCryptoCompare(
+  fsym: CoinKey,
+  tsym: Currency,
+  limit: number
+): Promise<{ Data: IHistoricalPriceData[] }> {
+  return (
+    await cryptoCompareClient.get("histoday", { params: { fsym, tsym, limit } })
+  ).data;
+}
+
+// ---------------------------------------------------------------------------
+// Public API (same signatures as before so existing callers are unaffected)
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch current prices for multiple coins in multiple currencies.
+ * Tries CoinGecko first, then CryptoCompare, each with up to 3 retries.
+ */
+export const getPriceMulti = async (
+  fsyms: CoinKey[],
+  tsyms: string[]
+): Promise<IPriceData> => {
+  try {
+    return await withRetry(() => fetchMultiPriceCoinGecko(fsyms, tsyms));
+  } catch {
+    // CoinGecko failed — try CryptoCompare
+    return await withRetry(() => fetchMultiPriceCryptoCompare(fsyms, tsyms));
+  }
+};
+
+/**
+ * Fetch the historical price for a single coin at a specific Unix timestamp.
+ * Uses CryptoCompare only (no CoinGecko equivalent on the free tier).
+ */
 export const getPriceHistorical = async (
   fsym: CoinKey,
   tsyms: string[],
   ts: number
 ): Promise<IPriceData> =>
-  (
-    await cryptoCompareClient.get("pricehistorical", {
-      params: { fsym, tsyms, ts },
-    })
-  ).data;
+  withRetry(() =>
+    cryptoCompareClient
+      .get("pricehistorical", { params: { fsym, tsyms, ts } })
+      .then((r) => r.data)
+  );
 
+/**
+ * Fetch daily OHLC history for a single coin.
+ * Tries CoinGecko first, then CryptoCompare, each with up to 3 retries.
+ */
 export const getPriceHistoricalDays = async (
   fsym: CoinKey,
   tsym: Currency = "AUD",
   limit: number = 10
-): Promise<{ Data: IHistoricalPriceData[] }> =>
-  (await cryptoCompareClient.get("histoday", { params: { fsym, tsym, limit } }))
-    .data;
+): Promise<{ Data: IHistoricalPriceData[] }> => {
+  try {
+    return await withRetry(() =>
+      fetchHistoricalDaysCoinGecko(fsym, tsym, limit)
+    );
+  } catch {
+    // CoinGecko failed — try CryptoCompare
+    return await withRetry(() =>
+      fetchHistoricalDaysCryptoCompare(fsym, tsym, limit)
+    );
+  }
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -42,6 +42,17 @@ export default defineConfig({
               },
             },
           },
+          {
+            urlPattern: /^https:\/\/api\.coingecko\.com\/.*/i,
+            handler: "NetworkFirst",
+            options: {
+              cacheName: "coingecko-api-cache",
+              expiration: {
+                maxEntries: 50,
+                maxAgeSeconds: 60 * 60, // 1 hour
+              },
+            },
+          },
         ],
       },
     }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -62,7 +62,7 @@
   resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz"
   integrity sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==
 
-"@babel/core@^7.0.0", "@babel/core@^7.0.0-0", "@babel/core@^7.0.0-0 || ^8.0.0-0 <8.0.0", "@babel/core@^7.12.0", "@babel/core@^7.13.0", "@babel/core@^7.24.4", "@babel/core@^7.28.0", "@babel/core@^7.4.0 || ^8.0.0-0 <8.0.0":
+"@babel/core@^7.24.4", "@babel/core@^7.28.0":
   version "7.29.0"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz"
   integrity sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==
@@ -1023,10 +1023,135 @@
   resolved "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz"
   integrity sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==
 
+"@esbuild/aix-ppc64@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz#80fcbe36130e58b7670511e888b8e88a259ed76c"
+  integrity sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==
+
+"@esbuild/android-arm64@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz#8aa4965f8d0a7982dc21734bf6601323a66da752"
+  integrity sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==
+
+"@esbuild/android-arm@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.25.12.tgz#300712101f7f50f1d2627a162e6e09b109b6767a"
+  integrity sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==
+
+"@esbuild/android-x64@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.25.12.tgz#87dfb27161202bdc958ef48bb61b09c758faee16"
+  integrity sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==
+
+"@esbuild/darwin-arm64@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz#79197898ec1ff745d21c071e1c7cc3c802f0c1fd"
+  integrity sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==
+
+"@esbuild/darwin-x64@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz#146400a8562133f45c4d2eadcf37ddd09718079e"
+  integrity sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==
+
+"@esbuild/freebsd-arm64@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz#1c5f9ba7206e158fd2b24c59fa2d2c8bb47ca0fe"
+  integrity sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==
+
+"@esbuild/freebsd-x64@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz#ea631f4a36beaac4b9279fa0fcc6ca29eaeeb2b3"
+  integrity sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==
+
+"@esbuild/linux-arm64@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz#e1066bce58394f1b1141deec8557a5f0a22f5977"
+  integrity sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==
+
+"@esbuild/linux-arm@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz#452cd66b20932d08bdc53a8b61c0e30baf4348b9"
+  integrity sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==
+
+"@esbuild/linux-ia32@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz#b24f8acc45bcf54192c7f2f3be1b53e6551eafe0"
+  integrity sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==
+
+"@esbuild/linux-loong64@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz#f9cfffa7fc8322571fbc4c8b3268caf15bd81ad0"
+  integrity sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==
+
+"@esbuild/linux-mips64el@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz#575a14bd74644ffab891adc7d7e60d275296f2cd"
+  integrity sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==
+
+"@esbuild/linux-ppc64@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz#75b99c70a95fbd5f7739d7692befe60601591869"
+  integrity sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==
+
+"@esbuild/linux-riscv64@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz#2e3259440321a44e79ddf7535c325057da875cd6"
+  integrity sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==
+
+"@esbuild/linux-s390x@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz#17676cabbfe5928da5b2a0d6df5d58cd08db2663"
+  integrity sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==
+
 "@esbuild/linux-x64@0.25.12":
   version "0.25.12"
   resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz"
   integrity sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==
+
+"@esbuild/netbsd-arm64@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz#f04c4049cb2e252fe96b16fed90f70746b13f4a4"
+  integrity sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==
+
+"@esbuild/netbsd-x64@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz#77da0d0a0d826d7c921eea3d40292548b258a076"
+  integrity sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==
+
+"@esbuild/openbsd-arm64@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz#6296f5867aedef28a81b22ab2009c786a952dccd"
+  integrity sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==
+
+"@esbuild/openbsd-x64@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz#f8d23303360e27b16cf065b23bbff43c14142679"
+  integrity sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==
+
+"@esbuild/openharmony-arm64@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz#49e0b768744a3924be0d7fd97dd6ce9b2923d88d"
+  integrity sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==
+
+"@esbuild/sunos-x64@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz#a6ed7d6778d67e528c81fb165b23f4911b9b13d6"
+  integrity sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==
+
+"@esbuild/win32-arm64@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz#9ac14c378e1b653af17d08e7d3ce34caef587323"
+  integrity sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==
+
+"@esbuild/win32-ia32@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz#918942dcbbb35cc14fca39afb91b5e6a3d127267"
+  integrity sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==
+
+"@esbuild/win32-x64@0.25.12":
+  version "0.25.12"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz#9bdad8176be7811ad148d1f8772359041f46c6c5"
+  integrity sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==
 
 "@exodus/bytes@^1.11.0", "@exodus/bytes@^1.15.0", "@exodus/bytes@^1.6.0":
   version "1.15.0"
@@ -1088,7 +1213,7 @@
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.5":
+"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
   version "2.0.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
@@ -1160,6 +1285,91 @@
     estree-walker "^2.0.2"
     picomatch "^4.0.2"
 
+"@rollup/rollup-android-arm-eabi@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz#a6742c74c7d9d6d604ef8a48f99326b4ecda3d82"
+  integrity sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==
+
+"@rollup/rollup-android-arm64@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz#97247be098de4df0c11971089fd2edf80a5da8cf"
+  integrity sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==
+
+"@rollup/rollup-darwin-arm64@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz#674852cf14cf11b8056e0b1a2f4e872b523576cf"
+  integrity sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==
+
+"@rollup/rollup-darwin-x64@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz#36dfd7ed0aaf4d9d89d9ef983af72632455b0246"
+  integrity sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==
+
+"@rollup/rollup-freebsd-arm64@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz#2f87c2074b4220260fdb52a9996246edfc633c22"
+  integrity sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==
+
+"@rollup/rollup-freebsd-x64@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz#9b5a26522a38a95dc06616d1939d4d9a76937803"
+  integrity sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==
+
+"@rollup/rollup-linux-arm-gnueabihf@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz#86aa4859385a8734235b5e40a48e52d770758c3a"
+  integrity sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==
+
+"@rollup/rollup-linux-arm-musleabihf@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz#cbe70e56e6ece8dac83eb773b624fc9e5a460976"
+  integrity sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==
+
+"@rollup/rollup-linux-arm64-gnu@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz#d14992a2e653bc3263d284bc6579b7a2890e1c45"
+  integrity sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==
+
+"@rollup/rollup-linux-arm64-musl@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz#2fdd1ddc434ea90aeaa0851d2044789b4d07f6da"
+  integrity sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==
+
+"@rollup/rollup-linux-loong64-gnu@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz#8a181e6f89f969f21666a743cd411416c80099e7"
+  integrity sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==
+
+"@rollup/rollup-linux-loong64-musl@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz#904125af2babc395f8061daa27b5af1f4e3f2f78"
+  integrity sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==
+
+"@rollup/rollup-linux-ppc64-gnu@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz#a57970ac6864c9a3447411a658224bdcf948be22"
+  integrity sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==
+
+"@rollup/rollup-linux-ppc64-musl@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz#bb84de5b26870567a4267666e08891e80bb56a63"
+  integrity sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==
+
+"@rollup/rollup-linux-riscv64-gnu@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz#72d00d2c7fb375ce3564e759db33f17a35bffab9"
+  integrity sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==
+
+"@rollup/rollup-linux-riscv64-musl@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz#4c166ef58e718f9245bd31873384ba15a5c1a883"
+  integrity sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==
+
+"@rollup/rollup-linux-s390x-gnu@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz#bb5025cde9a61db478c2ca7215808ad3bce73a09"
+  integrity sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==
+
 "@rollup/rollup-linux-x64-gnu@4.59.0":
   version "4.59.0"
   resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz"
@@ -1169,6 +1379,36 @@
   version "4.59.0"
   resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz"
   integrity sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==
+
+"@rollup/rollup-openbsd-x64@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz#e8b357b2d1aa2c8d76a98f5f0d889eabe93f4ef9"
+  integrity sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==
+
+"@rollup/rollup-openharmony-arm64@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz#96c2e3f4aacd3d921981329831ff8dde492204dc"
+  integrity sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==
+
+"@rollup/rollup-win32-arm64-msvc@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz#2d865149d706d938df8b4b8f117e69a77646d581"
+  integrity sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==
+
+"@rollup/rollup-win32-ia32-msvc@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz#abe1593be0fa92325e9971c8da429c5e05b92c36"
+  integrity sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==
+
+"@rollup/rollup-win32-x64-gnu@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz#c4af3e9518c9a5cd4b1c163dc81d0ad4d82e7eab"
+  integrity sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==
+
+"@rollup/rollup-win32-x64-msvc@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz#4584a8a87b29188a4c1fe987a9fcf701e256d86c"
+  integrity sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==
 
 "@standard-schema/spec@^1.1.0":
   version "1.1.0"
@@ -1185,7 +1425,7 @@
     magic-string "^0.25.0"
     string.prototype.matchall "^4.0.6"
 
-"@testing-library/dom@^10.0.0", "@testing-library/dom@>=7.21.4":
+"@testing-library/dom@^10.0.0":
   version "10.4.1"
   resolved "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz"
   integrity sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==
@@ -1228,7 +1468,7 @@
   resolved "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz"
   integrity sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==
 
-"@types/babel__core@^7.1.9", "@types/babel__core@^7.20.5":
+"@types/babel__core@^7.20.5":
   version "7.20.5"
   resolved "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz"
   integrity sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==
@@ -1325,15 +1565,15 @@
   resolved "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz"
   integrity sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==
 
-"@types/estree@^1.0.0", "@types/estree@1.0.8":
-  version "1.0.8"
-  resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz"
-  integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
-
 "@types/estree@0.0.39":
   version "0.0.39"
   resolved "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
+
+"@types/estree@1.0.8", "@types/estree@^1.0.0":
+  version "1.0.8"
+  resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz"
+  integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
 
 "@types/prop-types@*":
   version "15.7.7"
@@ -1345,12 +1585,12 @@
   resolved "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz"
   integrity sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==
 
-"@types/react-dom@^18.0.0 || ^19.0.0", "@types/react-dom@^18.3.1":
+"@types/react-dom@^18.3.1":
   version "18.3.7"
   resolved "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz"
   integrity sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==
 
-"@types/react@^18.0.0", "@types/react@^18.0.0 || ^19.0.0", "@types/react@^18.3.12":
+"@types/react@^18.3.12":
   version "18.3.28"
   resolved "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz"
   integrity sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==
@@ -1461,7 +1701,7 @@ acorn@^8.15.0:
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz"
   integrity sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
 
-ajv@^8.6.0, ajv@>=8:
+ajv@^8.6.0:
   version "8.12.0"
   resolved "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz"
   integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==
@@ -1506,7 +1746,7 @@ arg@^5.0.2:
   resolved "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz"
   integrity sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==
 
-aria-query@^5.0.0, aria-query@5.3.0:
+aria-query@5.3.0, aria-query@^5.0.0:
   version "5.3.0"
   resolved "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz"
   integrity sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==
@@ -1668,7 +1908,7 @@ braces@^3.0.3, braces@~3.0.2:
   dependencies:
     fill-range "^7.1.1"
 
-browserslist@^4.21.10, browserslist@^4.24.0, browserslist@^4.28.1, "browserslist@>= 4.21.0":
+browserslist@^4.21.10, browserslist@^4.24.0, browserslist@^4.28.1:
   version "4.28.1"
   resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz"
   integrity sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==
@@ -1839,7 +2079,7 @@ csstype@^3.0.2, csstype@^3.2.2:
   resolved "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz"
   integrity sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==
 
-d3-array@^3.1.6, "d3-array@2 - 3", "d3-array@2.10.0 - 3":
+"d3-array@2 - 3", "d3-array@2.10.0 - 3", d3-array@^3.1.6:
   version "3.2.4"
   resolved "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz"
   integrity sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==
@@ -1861,7 +2101,7 @@ d3-ease@^3.0.1:
   resolved "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz"
   integrity sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==
 
-d3-interpolate@^3.0.1, "d3-interpolate@1.2.0 - 3":
+"d3-interpolate@1.2.0 - 3", d3-interpolate@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz"
   integrity sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==
@@ -1898,7 +2138,7 @@ d3-shape@^3.1.0:
   dependencies:
     d3-time "1 - 3"
 
-d3-time@^3.0.0, "d3-time@1 - 3", "d3-time@2.1.1 - 3":
+"d3-time@1 - 3", "d3-time@2.1.1 - 3", d3-time@^3.0.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz"
   integrity sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==
@@ -2215,12 +2455,7 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.4"
 
-fdir@^6.4.4:
-  version "6.5.0"
-  resolved "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz"
-  integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
-
-fdir@^6.5.0:
+fdir@^6.4.4, fdir@^6.5.0:
   version "6.5.0"
   resolved "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz"
   integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
@@ -2285,6 +2520,11 @@ fs-extra@^9.0.1:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
+fsevents@~2.3.2, fsevents@~2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
+
 function-bind@^1.1.1, function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
@@ -2347,7 +2587,7 @@ get-symbol-description@^1.0.0:
     call-bind "^1.0.2"
     get-intrinsic "^1.1.1"
 
-glob-parent@^5.1.2:
+glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -2360,13 +2600,6 @@ glob-parent@^6.0.2:
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
   dependencies:
     is-glob "^4.0.3"
-
-glob-parent@~5.1.2:
-  version "5.1.2"
-  resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"
-  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
-  dependencies:
-    is-glob "^4.0.1"
 
 glob@^11.0.1:
   version "11.1.0"
@@ -2682,7 +2915,7 @@ jake@^10.8.5:
     filelist "^1.0.4"
     minimatch "^3.1.2"
 
-jiti@^1.21.7, jiti@>=1.21.0:
+jiti@^1.21.7:
   version "1.21.7"
   resolved "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz"
   integrity sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==
@@ -2697,7 +2930,7 @@ js-tokens@^10.0.0:
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-jsdom@*, jsdom@^29.0.0:
+jsdom@^29.0.0:
   version "29.0.0"
   resolved "https://registry.npmjs.org/jsdom/-/jsdom-29.0.0.tgz"
   integrity sha512-9FshNB6OepopZ08unmmGpsF7/qCjxGPbo3NbgfJAnPeHXnsODE9WWffXZtRFRFe0ntzaAOcSKNJFz8wiyvF1jQ==
@@ -2800,17 +3033,7 @@ loose-envify@^1.1.0, loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
-lru-cache@^11.0.0:
-  version "11.2.7"
-  resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz"
-  integrity sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==
-
-lru-cache@^11.2.6:
-  version "11.2.7"
-  resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz"
-  integrity sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==
-
-lru-cache@^11.2.7:
+lru-cache@^11.0.0, lru-cache@^11.2.6, lru-cache@^11.2.7:
   version "11.2.7"
   resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz"
   integrity sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==
@@ -3022,7 +3245,7 @@ pathe@^2.0.3:
   resolved "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz"
   integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
 
-picocolors@^1.1.1, picocolors@1.1.1:
+picocolors@1.1.1, picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
@@ -3032,7 +3255,7 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.2, picomatch@^2.3.1:
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
-"picomatch@^3 || ^4", picomatch@^4.0.2, picomatch@^4.0.3:
+picomatch@^4.0.2, picomatch@^4.0.3:
   version "4.0.3"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz"
   integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
@@ -3090,7 +3313,7 @@ postcss-value-parser@^4.0.0, postcss-value-parser@^4.2.0:
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8.0.0, postcss@^8.1.0, postcss@^8.2.14, postcss@^8.4.21, postcss@^8.4.47, postcss@^8.4.49, postcss@^8.5.3, postcss@>=8.0.9:
+postcss@^8.4.47, postcss@^8.4.49, postcss@^8.5.3:
   version "8.5.8"
   resolved "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz"
   integrity sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==
@@ -3163,7 +3386,7 @@ randombytes@^2.1.0:
   dependencies:
     safe-buffer "^5.1.0"
 
-"react-dom@^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom@^18.0.0 || ^19.0.0", react-dom@^18.3.1, react-dom@>=16.6.0:
+react-dom@^18.3.1:
   version "18.3.1"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz"
   integrity sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==
@@ -3210,7 +3433,7 @@ react-transition-group@^4.4.5:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-"react@^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^18.0.0 || ^19.0.0", react@^18.3.1, react@>=16.6.0:
+react@^18.3.1:
   version "18.3.1"
   resolved "https://registry.npmjs.org/react/-/react-18.3.1.tgz"
   integrity sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==
@@ -3326,14 +3549,14 @@ reusify@^1.0.4:
   resolved "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-"rollup@^1.20.0 || ^2.0.0", rollup@^1.20.0||^2.0.0, rollup@^2.79.2:
+rollup@^2.79.2:
   version "2.80.0"
   resolved "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz"
   integrity sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==
   optionalDependencies:
     fsevents "~2.3.2"
 
-rollup@^1.20.0||^2.0.0||^3.0.0||^4.0.0, rollup@^2.0.0||^3.0.0||^4.0.0, rollup@^2.78.0||^3.0.0||^4.0.0, rollup@^4.34.9:
+rollup@^4.34.9:
   version "4.59.0"
   resolved "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz"
   integrity sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==
@@ -3681,7 +3904,7 @@ tempy@^0.6.0:
     type-fest "^0.16.0"
     unique-string "^2.0.0"
 
-terser@^5.16.0, terser@^5.17.4:
+terser@^5.17.4:
   version "5.46.1"
   resolved "https://registry.npmjs.org/terser/-/terser-5.46.1.tgz"
   integrity sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==
@@ -3938,7 +4161,7 @@ vite-plugin-pwa@^0.21.1:
     workbox-build "^7.3.0"
     workbox-window "^7.3.0"
 
-"vite@^3.1.0 || ^4.0.0 || ^5.0.0 || ^6.0.0", "vite@^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0", "vite@^6.0.0 || ^7.0.0 || ^8.0.0-0", vite@^6.0.5:
+"vite@^6.0.0 || ^7.0.0 || ^8.0.0-0", vite@^6.0.5:
   version "6.4.1"
   resolved "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz"
   integrity sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==
@@ -3952,7 +4175,7 @@ vite-plugin-pwa@^0.21.1:
   optionalDependencies:
     fsevents "~2.3.3"
 
-vitest@^4.1.0, vitest@4.1.0:
+vitest@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz"
   integrity sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==
@@ -4000,16 +4223,7 @@ whatwg-mimetype@^5.0.0:
   resolved "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz"
   integrity sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==
 
-whatwg-url@^16.0.0:
-  version "16.0.1"
-  resolved "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz"
-  integrity sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==
-  dependencies:
-    "@exodus/bytes" "^1.11.0"
-    tr46 "^6.0.0"
-    webidl-conversions "^8.0.1"
-
-whatwg-url@^16.0.1:
+whatwg-url@^16.0.0, whatwg-url@^16.0.1:
   version "16.0.1"
   resolved "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz"
   integrity sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==
@@ -4214,7 +4428,7 @@ workbox-sw@7.4.0:
   resolved "https://registry.npmjs.org/workbox-sw/-/workbox-sw-7.4.0.tgz"
   integrity sha512-ltU+Kr3qWR6BtbdlMnCjobZKzeV1hN+S6UvDywBrwM19TTyqA03X66dzw1tEIdJvQ4lYKkBFox6IAEhoSEZ8Xw==
 
-workbox-window@^7.3.0, workbox-window@7.4.0:
+workbox-window@7.4.0, workbox-window@^7.3.0:
   version "7.4.0"
   resolved "https://registry.npmjs.org/workbox-window/-/workbox-window-7.4.0.tgz"
   integrity sha512-/bIYdBLAVsNR3v7gYGaV4pQW3M3kEPx5E8vDxGvxo6khTrGtSSCS7QiFKv9ogzBgZiy0OXLP9zO28U/1nF1mfw==


### PR DESCRIPTION
- Add CoinGecko as primary provider (free, 50 req/min) with coin ID mapping
  for all tracked assets; CryptoCompare retained as secondary fallback
- Add withRetry() utility with exponential back-off (3 attempts, 1/2/4s delays)
  applied to both providers so transient rate-limit errors are absorbed before
  failover occurs
- Today.tsx and History.tsx now wrap cached data with a cachedAt timestamp;
  on total API failure they surface the cached payload with an amber stale-data
  banner ("Live/Historical data unavailable — showing cached data from HH:mm")
  including an inline Retry button
- Update Workbox runtime caching to also cache CoinGecko API responses (1 h,
  NetworkFirst) so service-worker cache acts as an additional fallback layer
- Add apiProviders.test.ts covering withRetry success, retry, exhaustion, and
  no-retry cases; update cryptoService.test.ts to mock the new provider module
  and assert CoinGecko→CryptoCompare fallback; update History.test.tsx to match
  the number-input duration UI and add a stale-cache banner assertion

Optional: set VITE_COINGECKO_API_KEY for a higher rate limit on the demo tier.

https://claude.ai/code/session_01BqygHHsp32w6u3tcXNmoFS