### PR TITLE
refactor(Today): remove circular client→server→Pusher→client price flow

### DIFF
--- a/.claude/commands/upgrade-server.md
+++ b/.claude/commands/upgrade-server.md
@@ -1,0 +1,186 @@
+# Upgrade crypto-price-server: server-driven price broadcasting
+
+## Context
+
+The companion PWA (`crypto-price-pwa`) has been refactored so that when
+Pusher is configured it acts as a **passive subscriber only** — it no longer
+POSTs prices to the server. The server must now own the full fetch-and-broadcast
+cycle.
+
+The previous (broken) flow was:
+```
+PWA → fetches CoinGecko → POST /prices/new → Express → Pusher → PWA (circular)
+```
+
+The correct flow is:
+```
+Express server → fetches CoinGecko (+ CryptoCompare fallback) → Pusher broadcast
+                                                                       ↓
+                                                           PWA subscribes & displays
+                                                       (+ one initial direct fetch for fast start)
+```
+
+---
+
+## Task
+
+Upgrade `server.js` (and related files) so the server:
+
+1. **Fetches prices on a schedule** using `setInterval` (default every 60 s,
+   configurable via `FETCH_INTERVAL_MS` env var).
+2. **Fetches all 4 currencies at once** (AUD, USD, EUR, GBP) in a single
+   CoinGecko request so every connected PWA client can display their chosen
+   currency without extra calls.
+3. **Falls back to CryptoCompare** if CoinGecko fails (same retry strategy the
+   PWA already uses — up to 3 attempts with exponential backoff: 1 s, 2 s, 4 s).
+4. **Broadcasts the multi-currency payload** via the existing Pusher
+   `coin-prices` channel, `prices` event — same event name the PWA already
+   listens for.
+5. **Keeps `/prices/new`** as a manual override endpoint (useful for testing
+   and local dev without a running schedule).
+6. **Keeps the `GET /` health check** but extend the response to include
+   `lastFetchedAt` (ISO timestamp of the last successful price fetch).
+
+---
+
+## Coins and currencies
+
+Fetch these 7 coins in all 4 currencies in every scheduled request:
+
+| Symbol | CoinGecko ID  |
+|--------|---------------|
+| BTC    | bitcoin       |
+| ETH    | ethereum      |
+| XRP    | ripple        |
+| SOL    | solana        |
+| DOGE   | dogecoin      |
+| ADA    | cardano       |
+| LTC    | litecoin      |
+
+Currencies: `aud`, `usd`, `eur`, `gbp`
+
+---
+
+## CoinGecko API call
+
+```
+GET https://api.coingecko.com/api/v3/simple/price
+  ?ids=bitcoin,ethereum,ripple,solana,dogecoin,cardano,litecoin
+  &vs_currencies=aud,usd,eur,gbp
+  &x_cg_demo_api_key=<COINGECKO_API_KEY>   ← omit header/param if key not set
+```
+
+Response shape:
+```json
+{
+  "bitcoin":  { "aud": 150000, "usd": 98000, "eur": 90000, "gbp": 77000 },
+  "ethereum": { "aud": 5000,   "usd": 3200,  "eur": 2950,  "gbp": 2500  },
+  ...
+}
+```
+
+Map to the PWA's expected shape before broadcasting:
+```json
+{
+  "BTC": { "AUD": "150000", "USD": "98000", "EUR": "90000", "GBP": "77000" },
+  "ETH": { "AUD": "5000",   "USD": "3200",  "EUR": "2950",  "GBP": "2500"  },
+  ...
+}
+```
+
+---
+
+## CryptoCompare fallback API call
+
+```
+GET https://min-api.cryptocompare.com/data/pricemulti
+  ?fsyms=BTC,ETH,XRP,SOL,DOGE,ADA,LTC
+  &tsyms=AUD,USD,EUR,GBP
+  &api_key=<CRYPTOCOMPARE_API_KEY>
+```
+
+Response is already in the right shape.
+
+---
+
+## Pusher broadcast
+
+Trigger on the existing channel and event:
+- Channel: `coin-prices`
+- Event: `prices`
+- Payload: the mapped multi-currency object above
+
+---
+
+## Environment variables
+
+### Add to `.env` / `.env.example` on the server
+
+```dotenv
+# --- NEW ---
+
+# CoinGecko API key (optional — raises rate limit from 30 to 500 req/min)
+# Free demo key: https://www.coingecko.com/en/api/pricing
+COINGECKO_API_KEY=
+
+# CryptoCompare API key (fallback provider, required for fallback to work)
+# Free key: https://www.cryptocompare.com/cryptopian/api-keys
+CRYPTOCOMPARE_API_KEY=
+
+# How often (ms) to fetch and broadcast prices. Defaults to 60000 (60 s).
+FETCH_INTERVAL_MS=60000
+```
+
+### Existing vars — no changes needed
+
+```dotenv
+PUSHER_ID=
+PUSHER_KEY=
+PUSHER_SECRET=
+PUSHER_CLUSTER=
+PORT=5000
+CORS_ORIGIN=*
+```
+
+### Remove from `.env` on the server (no longer sent by client)
+
+None — the server never relied on client-sent API keys, so nothing to remove.
+
+---
+
+## PWA environment variables
+
+The PWA (`crypto-price-pwa`) already has these changes committed.
+For reference, its `.env` / `.env.example` is now:
+
+```dotenv
+# CryptoCompare fallback (used only in polling mode — no Pusher)
+VITE_COIN_API_KEY=
+
+# Pusher subscribe credentials (read-only — PWA never publishes)
+VITE_PUSHER_KEY=
+VITE_PUSHER_CLUSTER=
+
+# REMOVED: VITE_PUSHER_API — client no longer POSTs prices to the server
+```
+
+---
+
+## Implementation notes
+
+- Use `axios` (already a dependency via the existing server) or Node's built-in
+  `fetch` (Node >= 18) for the HTTP calls — do not add new HTTP client packages.
+- Keep the fetch logic in a dedicated module `priceService.js` (or inline in
+  `server.js` if you prefer minimal footprint) — do not add a heavyweight
+  framework.
+- If a scheduled fetch fails after all retries, log the error but **do not
+  crash** — the next interval will try again.
+- On server startup, run the first fetch immediately (don't wait 60 s for the
+  first broadcast).
+- Update `server.test.js` to cover:
+  - Scheduled fetch calls the price API and triggers a Pusher broadcast
+  - CryptoCompare fallback is used when CoinGecko fails
+  - `/prices/new` manual override still works
+  - `GET /` includes `lastFetchedAt` in the response
+- Update `README.md` to reflect the new server-driven architecture and the
+  new env vars.

--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,11 @@
-# CryptoCompare API key
+# CryptoCompare API key (fallback provider)
 # Sign up for a free account at https://www.cryptocompare.com/cryptopian/api-keys
 # Create an API key and paste it here
 VITE_COIN_API_KEY=
 
-# Pusher credentials
-# Sign up at https://pusher.com/, create a new Channels app, then copy the values below
+# Pusher credentials (optional — enables server-driven live updates)
+# Sign up at https://pusher.com/, create a new Channels app, then copy the values below.
+# When set, the crypto-price-server broadcasts prices on the "coin-prices" channel
+# and this app subscribes. Without these vars the app falls back to polling every 60 s.
 VITE_PUSHER_KEY=
 VITE_PUSHER_CLUSTER=
-
-# URL of your crypto-price-server backend (handles Pusher broadcasting)
-# See: https://github.com/your-org/crypto-price-server
-VITE_PUSHER_API=

--- a/src/Today/Today.test.tsx
+++ b/src/Today/Today.test.tsx
@@ -15,6 +15,7 @@ vi.mock("pusher-js", () => ({
     }),
     connection: { bind: vi.fn() },
     unsubscribe: vi.fn(),
+    disconnect: vi.fn(),
   })),
 }));
 

--- a/src/Today/Today.tsx
+++ b/src/Today/Today.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useRef } from "react";
-import axios from "axios";
 import Pusher from "pusher-js";
 import { format } from "date-fns";
 import { enAU } from "date-fns/locale";
@@ -10,7 +9,23 @@ import { LoadingState, ErrorState, EmptyState } from "../Results";
 
 const cluster = import.meta.env.VITE_PUSHER_CLUSTER;
 const appKey = import.meta.env.VITE_PUSHER_KEY;
-const pusherApi = import.meta.env.VITE_PUSHER_API;
+
+/**
+ * Architecture note
+ * -----------------
+ * When Pusher env vars are set, the server (crypto-price-server) is responsible
+ * for fetching prices on a schedule and broadcasting them via the "coin-prices"
+ * Pusher channel. This component performs ONE initial fetch so the UI populates
+ * immediately without waiting for the next broadcast, then switches to a
+ * purely passive listener — no client-side polling loop is started.
+ *
+ * When Pusher is NOT configured the component falls back to direct polling
+ * (every 60 s) against CoinGecko / CryptoCompare.
+ *
+ * This eliminates the previous circular flow where the client was both
+ * fetching prices from the APIs AND posting them back to the server so the
+ * server could re-broadcast them via Pusher to the same client.
+ */
 
 /** Cache entry stored in localStorage — wraps the price payload with a timestamp */
 interface TodayCacheEntry {
@@ -97,18 +112,6 @@ const Today = ({ currency, onPriceUpdate }: TodayProps) => {
     }
   };
 
-  const sendPricePusher = (response: ITodayCurrencyPriceData) => {
-    const payload: Record<string, string | number | undefined> = {
-      date: response.date,
-    };
-    ALL_COIN_KEYS.forEach((key) => {
-      if (response[key]) payload[key] = response[key];
-    });
-    axios
-      .post(`${pusherApi}/prices/new`, payload)
-      .catch((err) => console.error("Pusher post error:", err));
-  };
-
   const handleSuccess = (response: ITodayCurrencyPriceData) => {
     const hasAnyPrice = ALL_COIN_KEYS.some((key) => response[key]);
     if (response && hasAnyPrice) {
@@ -162,7 +165,11 @@ const Today = ({ currency, onPriceUpdate }: TodayProps) => {
     setStatus("error");
   };
 
-  const fetchResults = (callback = handleSuccess, statusChange = true) => {
+  /**
+   * Fetch prices directly from the API and update the UI.
+   * Used for the initial load and for the polling fallback.
+   */
+  const fetchResults = (statusChange = true) => {
     if (statusChange) setStatus("loading");
     getPriceMulti(ALL_COIN_KEYS, [currency])
       .then((res) => {
@@ -173,11 +180,20 @@ const Today = ({ currency, onPriceUpdate }: TodayProps) => {
           data[key] = rawStr ? formatCurrency(parseFloat(rawStr), currency) : "—";
           data[`${key}_raw`] = rawStr ? parseFloat(rawStr) : undefined;
         });
-        callback(data);
+        handleSuccess(data);
       })
       .catch(handleError);
+  };
 
-    timerRef.current = setTimeout(() => fetchResults(sendPricePusher), 60000);
+  /**
+   * Polling loop: fetch prices every 60 s, used when Pusher is not configured.
+   * In Pusher mode the server drives updates — no client-side loop is needed.
+   */
+  const schedulePoll = () => {
+    timerRef.current = setTimeout(() => {
+      fetchResults(false);
+      schedulePoll();
+    }, 60_000);
   };
 
   useEffect(() => {
@@ -187,29 +203,38 @@ const Today = ({ currency, onPriceUpdate }: TodayProps) => {
     }
 
     if (appKey && cluster) {
+      // --- Pusher mode ---
+      // The server fetches prices on a schedule and broadcasts them here.
+      // We do one initial direct fetch so data appears immediately, then
+      // rely entirely on incoming Pusher events — no polling loop.
       const pusher = new Pusher(appKey, {
         cluster,
         forceTLS: true,
         enabledTransports: ["ws", "wss", "xhr_polling"],
       });
 
-      const prices = pusher.subscribe("coin-prices");
-      fetchResults();
+      const channel = pusher.subscribe("coin-prices");
 
       pusher.connection.bind("error", (err: unknown) => {
         console.error("Pusher connection error:", err);
       });
 
-      prices.bind("prices", (data: ITodayCurrencyPriceData) => {
+      channel.bind("prices", (data: ITodayCurrencyPriceData) => {
         handleSuccess(data);
       });
+
+      // Initial fetch so the UI isn't empty while waiting for first broadcast
+      fetchResults();
 
       return () => {
         clearTimeout(timerRef.current);
         pusher.unsubscribe("coin-prices");
+        pusher.disconnect();
       };
     } else {
+      // --- Polling mode ---
       fetchResults();
+      schedulePoll();
       return () => clearTimeout(timerRef.current);
     }
   }, [currency]);


### PR DESCRIPTION
The previous architecture had a confusing circular dependency:
1. PWA fetched prices from CoinGecko/CryptoCompare
2. POSTed them to the Express server (VITE_PUSHER_API)
3. Server broadcast via Pusher
4. PWA received its own prices back via WebSocket

This inverts the responsibility correctly:
- In Pusher mode: PWA does ONE initial fetch for immediate display,
  then purely listens for server-broadcast updates (no polling loop).
  The crypto-price-server should own the fetch-and-broadcast schedule.
- In polling mode (no Pusher): client polls every 60 s as before.

Also removes VITE_PUSHER_API from .env.example since the client no
longer needs to POST prices to the server. Adds pusher.disconnect()
to cleanup and updates the test mock accordingly.

https://claude.ai/code/session_017m3jVkCJBPfJJv21f8Xz8R