### PR TITLE
Fix price loading reliability, date selector, history date range, and per-coin error states

### DIFF
--- a/src/History/History.tsx
+++ b/src/History/History.tsx
@@ -30,37 +30,28 @@ interface HistoryCacheEntry {
   cachedAt: number; // Unix ms
 }
 
-type TimeUnit = "days" | "weeks" | "months";
+type TimePreset = "1D" | "1W" | "1M" | "3M" | "6M" | "1Y";
 
-const UNIT_CONFIG: Record<TimeUnit, { min: number; max: number; toDays: (n: number) => number; label: string }> = {
-  days:   { min: 2,  max: 90,  toDays: (n) => n,      label: "Days"   },
-  weeks:  { min: 1,  max: 52,  toDays: (n) => n * 7,  label: "Weeks"  },
-  months: { min: 1,  max: 24,  toDays: (n) => n * 30, label: "Months" },
-};
+const PRESETS: { label: TimePreset; days: number }[] = [
+  { label: "1D", days: 1 },
+  { label: "1W", days: 7 },
+  { label: "1M", days: 30 },
+  { label: "3M", days: 90 },
+  { label: "6M", days: 180 },
+  { label: "1Y", days: 365 },
+];
 
 const History = ({ currency }: HistoryProps) => {
-  const [amount, setAmount] = useState<number>(7);
-  const [unit, setUnit] = useState<TimeUnit>("days");
+  const [preset, setPreset] = useState<TimePreset>("1W");
   const [chartData, setChartData] = useState<ChartDataPoint[]>([]);
+  const [failedCoins, setFailedCoins] = useState<CoinKey[]>([]);
   const [error, setError] = useState<string>("");
   const [activeView, setActiveView] = useState<"chart" | "table">("chart");
   const [isStale, setIsStale] = useState(false);
   const [cacheTime, setCacheTime] = useState<string>();
   const { Status, setStatus } = useStatus("loading");
 
-  const numDays = UNIT_CONFIG[unit].toDays(amount);
-
-  const handleUnitChange = (newUnit: TimeUnit) => {
-    const cfg = UNIT_CONFIG[newUnit];
-    setUnit(newUnit);
-    setAmount((prev) => Math.min(Math.max(prev, cfg.min), cfg.max));
-  };
-
-  const handleAmountChange = (value: string) => {
-    const n = parseInt(value, 10);
-    const cfg = UNIT_CONFIG[unit];
-    if (!isNaN(n)) setAmount(Math.min(Math.max(n, cfg.min), cfg.max));
-  };
+  const numDays = PRESETS.find((p) => p.label === preset)!.days;
 
   const restoreStateFromLocalStorage = useCallback(() => {
     const raw = localStorage.getItem(`history-chart-${numDays}`);
@@ -93,26 +84,40 @@ const History = ({ currency }: HistoryProps) => {
   const fetchDays = useCallback(async () => {
     setStatus("loading");
     try {
-      const results = await Promise.all(
+      // Use allSettled so a single coin failure doesn't block the whole chart
+      const settled = await Promise.allSettled(
         ALL_COIN_KEYS.map((coin) => getPriceHistoricalDays(coin, currency, numDays))
       );
 
-      const points: ChartDataPoint[] = [];
-      const firstCoinData = results[0].Data;
-      for (let i = numDays - 1; i >= 0; i--) {
-        const entry = firstCoinData[i];
-        if (!entry) continue;
+      // Track which coins failed or returned empty data
+      const failed: CoinKey[] = [];
+      const coinData: (IHistoricalPriceData[] | null)[] = settled.map((result, i) => {
+        if (result.status === "rejected" || !result.value.Data.length) {
+          failed.push(ALL_COIN_KEYS[i]);
+          return null;
+        }
+        return result.value.Data;
+      });
+
+      // Need at least one coin with data to render the chart
+      const referenceData = coinData.find((d) => d !== null);
+      if (!referenceData) throw new Error("No historical data available for any coin");
+
+      // Build chart points in chronological order (oldest → newest)
+      // CoinGecko returns data oldest-first; iterate in natural order
+      const points: ChartDataPoint[] = referenceData.map((entry, i) => {
         const point: ChartDataPoint = {
-          date: format(fromUnixTime(entry.time), "MMM d"),
+          date: format(fromUnixTime(entry.time), numDays <= 1 ? "HH:mm" : "MMM d"),
         };
         ALL_COIN_KEYS.forEach((coin, idx) => {
-          const d = results[idx].Data[i];
+          const d = coinData[idx]?.[i];
           point[coin] = d ? d.close : 0;
         });
-        points.push(point);
-      }
+        return point;
+      });
 
       setChartData(points);
+      setFailedCoins(failed);
       saveToLocalStorage(points);
       setIsStale(false);
       setCacheTime(undefined);
@@ -165,32 +170,21 @@ const History = ({ currency }: HistoryProps) => {
         </h2>
 
         <div className="flex items-center gap-3 flex-wrap">
-          {/* Duration input */}
-          <div className="flex items-center gap-1.5 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg px-3 py-1.5">
-            <input
-              type="number"
-              value={amount}
-              min={UNIT_CONFIG[unit].min}
-              max={UNIT_CONFIG[unit].max}
-              onChange={(e) => handleAmountChange(e.target.value)}
-              className="w-12 text-sm font-semibold text-center text-slate-900 dark:text-slate-100 bg-transparent tabular-nums focus:outline-none"
-              aria-label="Duration amount"
-            />
-            <div className="flex items-center bg-slate-100 dark:bg-slate-700 rounded-md p-0.5 gap-0.5">
-              {(["days", "weeks", "months"] as TimeUnit[]).map((u) => (
-                <button
-                  key={u}
-                  onClick={() => handleUnitChange(u)}
-                  className={`px-2 py-0.5 rounded text-xs font-semibold capitalize transition-all duration-200 ${
-                    unit === u
-                      ? "bg-white dark:bg-slate-600 text-slate-900 dark:text-white shadow-sm"
-                      : "text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200"
-                  }`}
-                >
-                  {u}
-                </button>
-              ))}
-            </div>
+          {/* Preset time range selector */}
+          <div className="flex items-center bg-slate-100 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg p-1 gap-0.5">
+            {PRESETS.map(({ label }) => (
+              <button
+                key={label}
+                onClick={() => setPreset(label)}
+                className={`px-2.5 py-1 rounded-md text-xs font-semibold transition-all duration-200 ${
+                  preset === label
+                    ? "bg-white dark:bg-slate-600 text-slate-900 dark:text-white shadow-sm"
+                    : "text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200"
+                }`}
+              >
+                {label}
+              </button>
+            ))}
           </div>
 
           {/* View toggle */}
@@ -242,6 +236,7 @@ const History = ({ currency }: HistoryProps) => {
               <div className="p-4 sm:p-6 space-y-6">
                 {ALL_COIN_KEYS.map((coin) => {
                   const meta = COIN_META[coin];
+                  const hasFailed = failedCoins.includes(coin);
                   return (
                     <div key={coin}>
                       <h3 className="text-sm font-medium text-slate-500 dark:text-slate-400 mb-3 flex items-center gap-2">
@@ -251,26 +246,41 @@ const History = ({ currency }: HistoryProps) => {
                         ></span>
                         {meta.name} ({coin})
                       </h3>
-                      <ResponsiveContainer width="100%" height={140}>
-                        <LineChart data={chartData} margin={{ top: 2, right: 8, bottom: 0, left: 0 }}>
-                          <CartesianGrid strokeDasharray="3 3" stroke="rgba(148,163,184,0.2)" />
-                          <XAxis dataKey="date" tick={{ fontSize: 11, fill: "currentColor" }} tickLine={false} axisLine={false} />
-                          <YAxis
-                            tickFormatter={(v: number) => formatCurrency(v, currency).replace(/\.\d+/, "")}
-                            tick={{ fontSize: 10, fill: "currentColor" }}
-                            tickLine={false}
-                            axisLine={false}
-                            width={80}
-                          />
-                          <Tooltip
-                            formatter={formatTooltipValue}
-                            contentStyle={{ backgroundColor: "var(--tooltip-bg, #1e293b)", border: "none", borderRadius: "8px", fontSize: "12px" }}
-                            labelStyle={{ color: "#94a3b8" }}
-                            itemStyle={{ color: "#f8fafc" }}
-                          />
-                          <Line type="monotone" dataKey={coin} stroke={meta.color} strokeWidth={2} dot={false} name={coin} />
-                        </LineChart>
-                      </ResponsiveContainer>
+                      {hasFailed ? (
+                        <div className="flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 px-3 py-3 text-xs text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
+                          <svg className="h-4 w-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9.303-3.376c.866 1.5-.217 3.374-1.948 3.374H4.645c-1.73 0-2.813-1.874-1.948-3.374L10.05 3.378c.866-1.5 3.032-1.5 3.898 0l5.355 9.246zM12 15.75h.007v.008H12v-.008z" />
+                          </svg>
+                          Unable to load price history for {meta.name}
+                          <button
+                            onClick={fetchDays}
+                            className="ml-1 underline underline-offset-2 hover:text-red-900 dark:hover:text-red-300"
+                          >
+                            Retry
+                          </button>
+                        </div>
+                      ) : (
+                        <ResponsiveContainer width="100%" height={140}>
+                          <LineChart data={chartData} margin={{ top: 2, right: 8, bottom: 0, left: 0 }}>
+                            <CartesianGrid strokeDasharray="3 3" stroke="rgba(148,163,184,0.2)" />
+                            <XAxis dataKey="date" tick={{ fontSize: 11, fill: "currentColor" }} tickLine={false} axisLine={false} />
+                            <YAxis
+                              tickFormatter={(v: number) => formatCurrency(v, currency).replace(/\.\d+/, "")}
+                              tick={{ fontSize: 10, fill: "currentColor" }}
+                              tickLine={false}
+                              axisLine={false}
+                              width={80}
+                            />
+                            <Tooltip
+                              formatter={formatTooltipValue}
+                              contentStyle={{ backgroundColor: "var(--tooltip-bg, #1e293b)", border: "none", borderRadius: "8px", fontSize: "12px" }}
+                              labelStyle={{ color: "#94a3b8" }}
+                              itemStyle={{ color: "#f8fafc" }}
+                            />
+                            <Line type="monotone" dataKey={coin} stroke={meta.color} strokeWidth={2} dot={false} name={coin} />
+                          </LineChart>
+                        </ResponsiveContainer>
+                      )}
                     </div>
                   );
                 })}
@@ -310,7 +320,11 @@ const History = ({ currency }: HistoryProps) => {
                             key={key}
                             className="px-4 py-3 text-right text-slate-900 dark:text-slate-100 tabular-nums"
                           >
-                            {formatCurrency(row[key] as number, currency)}
+                            {failedCoins.includes(key) ? (
+                              <span className="text-red-400 dark:text-red-500 text-xs">—</span>
+                            ) : (
+                              formatCurrency(row[key] as number, currency)
+                            )}
                           </td>
                         ))}
                       </tr>

--- a/src/Today/Today.tsx
+++ b/src/Today/Today.tsx
@@ -199,44 +199,57 @@ const Today = ({ currency, onPriceUpdate }: TodayProps) => {
   useEffect(() => {
     if (!window.navigator.onLine) {
       restoreStateFromLocalStorage();
-      return;
+    } else {
+      fetchResults();
     }
 
-    if (appKey && cluster) {
-      // --- Pusher mode ---
-      // The server fetches prices on a schedule and broadcasts them here.
-      // We do one initial direct fetch so data appears immediately, then
-      // rely entirely on incoming Pusher events — no polling loop.
-      const pusher = new Pusher(appKey, {
-        cluster,
-        forceTLS: true,
-        enabledTransports: ["ws", "wss", "xhr_polling"],
-      });
-
-      const channel = pusher.subscribe("coin-prices");
-
-      pusher.connection.bind("error", (err: unknown) => {
-        console.error("Pusher connection error:", err);
-      });
-
-      channel.bind("prices", (data: ITodayCurrencyPriceData) => {
-        handleSuccess(data);
-      });
-
-      // Initial fetch so the UI isn't empty while waiting for first broadcast
+    // Auto-retry when the device comes back online
+    const handleOnline = () => {
       fetchResults();
+    };
+    window.addEventListener("online", handleOnline);
 
-      return () => {
-        clearTimeout(timerRef.current);
-        pusher.unsubscribe("coin-prices");
-        pusher.disconnect();
-      };
-    } else {
+    return () => {
+      window.removeEventListener("online", handleOnline);
+    };
+  }, [currency]);
+
+  useEffect(() => {
+    if (!appKey || !cluster) {
       // --- Polling mode ---
-      fetchResults();
       schedulePoll();
       return () => clearTimeout(timerRef.current);
     }
+
+    // --- Pusher mode ---
+    const pusher = new Pusher(appKey, {
+      cluster,
+      forceTLS: true,
+      enabledTransports: ["ws", "wss", "xhr_polling"],
+    });
+
+    const channel = pusher.subscribe("coin-prices");
+
+    // If Pusher fails to connect, fall back to polling
+    pusher.connection.bind("error", (err: unknown) => {
+      console.error("Pusher connection error:", err);
+      if (!timerRef.current) schedulePoll();
+    });
+
+    pusher.connection.bind("failed", () => {
+      console.warn("Pusher connection failed — falling back to polling");
+      if (!timerRef.current) schedulePoll();
+    });
+
+    channel.bind("prices", (data: ITodayCurrencyPriceData) => {
+      handleSuccess(data);
+    });
+
+    return () => {
+      clearTimeout(timerRef.current);
+      pusher.unsubscribe("coin-prices");
+      pusher.disconnect();
+    };
   }, [currency]);
 
   return (

--- a/src/apiProviders.ts
+++ b/src/apiProviders.ts
@@ -123,6 +123,10 @@ export async function fetchHistoricalDaysCoinGecko(
     headers: coingeckoHeaders(),
   });
 
+  if (!data.prices.length) {
+    throw new Error(`No historical price data returned by CoinGecko for ${coin}`);
+  }
+
   const historicalData: IHistoricalPriceData[] = data.prices.map(
     ([tsMs, price], i) => ({
       time: Math.floor(tsMs / 1000),


### PR DESCRIPTION
- Today: add online event listener for auto-retry when network reconnects; split
  useEffect so Pusher connection errors fall back to polling rather than leaving
  the UI stale on mobile
- History: replace freeform number+unit input with standard preset buttons
  (1D / 1W / 1M / 3M / 6M / 1Y) matching the expected mobile UI pattern
- History: fix chart date range — iterate CoinGecko data in natural chronological
  order (oldest → newest) instead of reversed index loop that produced wrong
  dates and missed the most-recent data point
- History: use Promise.allSettled so a single coin fetch failure no longer
  silences the entire chart; failed coins render a per-coin error banner with a
  retry button instead of a flat $0 line
- apiProviders: throw an explicit error when CoinGecko returns empty price data
  so the per-coin error path is correctly triggered instead of silently plotting
  zeros

https://claude.ai/code/session_017u3Jddq51zHHGqoEhxLiTF